### PR TITLE
Add type hints to sort function

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -7,7 +7,7 @@ Repository: https://github.com/Pavankumar-3/Pavankumar-3
 """
 
 
-def sort(width, height, length, mass):
+def sort(width: float, height: float, length: float, mass: float) -> str:
     """Return the stack name for a package.
 
     Parameters:
@@ -15,6 +15,9 @@ def sort(width, height, length, mass):
         height (float): height in cm
         length (float): length in cm
         mass (float): mass in kg
+
+    Returns:
+        str: ``STANDARD``, ``SPECIAL``, or ``REJECTED`` classification.
     """
     volume = width * height * length
     bulky = volume >= 1_000_000 or max(width, height, length) >= 150


### PR DESCRIPTION
## Summary
- add type hints to `sort` parameters and return value
- document return value in `sort` docstring

## Testing
- `python3 -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68b60cd7bed483268443a775f8ea1264